### PR TITLE
correct drawPixel line to account for png_dx and png_dy set by setPngPosition

### DIFF
--- a/png_test_url_spiffs_2x/support_functions.h
+++ b/png_test_url_spiffs_2x/support_functions.h
@@ -49,7 +49,7 @@ void pngle_on_draw(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t 
       px++; lbuf[pc++] = color;
     }
   #else
-    tft.drawPixel(x, y, color);
+    tft.drawPixel(x+png_dx, y+png_dy, color);
   #endif
   }
 }


### PR DESCRIPTION
Without this change, the PNG is always drawn starting at 0,0 no matter what you set in setPngPosition. 